### PR TITLE
fix(cli): expand ~/ in local paths and save wallpapers as PNG

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -38,12 +38,12 @@ pub fn parse_cli_args(args: Vec<String>) -> Config {
 /// # Returns
 /// A random keyword
 fn choose_random_keyword(keywords: Vec<String>) -> String {
-    return if keywords.len() > 1 {
+    if keywords.len() > 1 {
         let random_index = rand::thread_rng().gen_range(0..keywords.len());
         keywords.get(random_index).unwrap().to_string()
     } else {
-        keywords.get(0).unwrap().to_string()
-    };
+        keywords.first().unwrap().to_string()
+    }
 }
 
 /// Remove an element from a vector
@@ -69,11 +69,22 @@ pub fn is_url(to_check: &str) -> bool {
     to_check.starts_with("http") && to_check.contains("://")
 }
 
+/// Expand a leading '~/' to the user's home directory
+fn expand_tilde(path: &str) -> String {
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(rest).to_string_lossy().into_owned();
+        }
+    }
+    path.to_string()
+}
+
 /// Check if a string is a local path
 /// # Arguments
 /// * `to_check` - The string to check
 /// # Returns
 /// True if the string is a local path
 pub fn is_local_path(to_check: &str) -> bool {
-    return Path::new(to_check).exists();
+    let expanded = expand_tilde(to_check);
+    Path::new(&expanded).exists()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,15 +69,7 @@ pub fn is_url(to_check: &str) -> bool {
     to_check.starts_with("http") && to_check.contains("://")
 }
 
-/// Expand a leading '~/' to the user's home directory
-fn expand_tilde(path: &str) -> String {
-    if let Some(rest) = path.strip_prefix("~/") {
-        if let Some(home) = dirs::home_dir() {
-            return home.join(rest).to_string_lossy().into_owned();
-        }
-    }
-    path.to_string()
-}
+use crate::utils::expand_tilde;
 
 /// Check if a string is a local path
 /// # Arguments

--- a/src/display.rs
+++ b/src/display.rs
@@ -5,7 +5,9 @@ use crate::cli;
 
 /// Container that holds information about the display current configuration
 pub struct DisplayInfo {
+    #[allow(dead_code)]
     pub count: i8,
+    #[allow(dead_code)]
     pub resolutions: Vec<String>,
     pub total_resolution: String,
     pub max_single_resolution: String,
@@ -75,12 +77,12 @@ fn multiply_resolution(resolution: &str) -> i32 {
 /// Gets the total desktop resolution.
 /// # Example Two desktops (1) 1920x1080 (2) 1920x1080 | get_total_resolution() -> "3840x1080"
 pub fn get_total_resolution() -> String {
-    return execute_display_command(
+    execute_display_command(
         r#"xprop -notype -len 16 -root _NET_DESKTOP_GEOMETRY | cut -c 25-"#,
     )
     .replace(", ", "x")
     .trim()
-    .to_string();
+    .to_string()
 }
 
 /// Gets all available display resolutions
@@ -123,11 +125,11 @@ fn is_display_var_set() -> bool {
 /// assert_eq!(get_width("1920x1080"), 1920);
 /// ```
 pub fn get_width(resolution_string: &str) -> String {
-    return resolution_string
+    resolution_string
         .split('x')
         .next()
         .expect("wrong display resolution format")
-        .to_string();
+        .to_string()
 }
 
 /// Gets the height of a resolution string
@@ -141,9 +143,9 @@ pub fn get_width(resolution_string: &str) -> String {
 /// assert_eq!(get_height("1920x1080"), 1080);
 /// ```
 pub fn get_height(resolution_string: &str) -> String {
-    return resolution_string
+    resolution_string
         .split('x')
         .nth(1)
         .expect("wrong display resolution format")
-        .to_string();
+        .to_string()
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -77,12 +77,10 @@ fn multiply_resolution(resolution: &str) -> i32 {
 /// Gets the total desktop resolution.
 /// # Example Two desktops (1) 1920x1080 (2) 1920x1080 | get_total_resolution() -> "3840x1080"
 pub fn get_total_resolution() -> String {
-    execute_display_command(
-        r#"xprop -notype -len 16 -root _NET_DESKTOP_GEOMETRY | cut -c 25-"#,
-    )
-    .replace(", ", "x")
-    .trim()
-    .to_string()
+    execute_display_command(r#"xprop -notype -len 16 -root _NET_DESKTOP_GEOMETRY | cut -c 25-"#)
+        .replace(", ", "x")
+        .trim()
+        .to_string()
 }
 
 /// Gets all available display resolutions

--- a/src/display_manager.rs
+++ b/src/display_manager.rs
@@ -115,10 +115,10 @@ fn set_gnome_wallpaper(picture_option: &str, wallpaper_file_path_fqdn: &str) {
 
 /// Gets the name of the current display manager
 fn get_display_manager() -> String {
-    return env::var("XDG_CURRENT_DESKTOP")
+    env::var("XDG_CURRENT_DESKTOP")
         .unwrap()
         .trim()
-        .to_lowercase();
+        .to_lowercase()
 }
 
 /// Clears the wallpaper directory
@@ -133,9 +133,11 @@ fn clear_wallpaper_dir() {
 /// * `image` - The image to store
 /// # Returns the path to the file
 fn persist_to_file(image_data: DynamicImage) -> String {
+    // Save as PNG to avoid JPEG RGBA unsupported errors, DEs accept PNG
     let path = build_target_path();
     image_data
-        .save(path.as_str())
+        .to_rgba8()
+        .save_with_format(path.as_str(), image::ImageFormat::Png)
         .expect("Unable to save image");
     path
 }
@@ -148,7 +150,7 @@ fn build_target_path() -> String {
         .unwrap()
         .as_millis()
         .to_string();
-    let file_name = format!("{current_millis}.jpg");
+    let file_name = format!("{current_millis}.png");
 
     dirs::home_dir()
         .unwrap()

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -13,7 +13,7 @@ fn expand_tilde(path: &str) -> String {
     }
     path.to_string()
 }
-
+use crate::utils::expand_tilde;
 /// Reads data from a local file path
 /// If the provided path is a directory, a random image is chosen
 pub fn read_file(file_path: &str) -> Vec<u8> {

--- a/src/image_processor.rs
+++ b/src/image_processor.rs
@@ -94,12 +94,12 @@ fn calculate_display_ratio(span: bool, display_info: &&DisplayInfo) -> f32 {
 /// assert_eq!(display_width, 1920);
 /// ```
 fn get_width(resolution_string: &str) -> usize {
-    return resolution_string
+    resolution_string
         .split('x')
         .next()
         .expect("wrong display resolution format")
         .parse()
-        .unwrap();
+        .unwrap()
 }
 
 /// Gets the height of the resolution string
@@ -118,10 +118,10 @@ fn get_width(resolution_string: &str) -> usize {
 /// assert_eq!(display_height, 1080);
 /// ```
 fn get_height(resolution_string: &str) -> usize {
-    return resolution_string
+    resolution_string
         .split('x')
         .nth(1)
         .expect("wrong display resolution format")
         .parse()
-        .unwrap();
+        .unwrap()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod gnome;
 mod image_processor;
 mod kde;
 mod pixabay;
+mod utils;
 mod xfce;
 
 #[cfg(test)]

--- a/src/pixabay.rs
+++ b/src/pixabay.rs
@@ -41,7 +41,7 @@ fn get_image_url(config: &Config, display_info: &DisplayInfo) -> String {
         .collect();
 
     let random_index = rand::thread_rng().gen_range(0..images.len());
-    return images.get(random_index).unwrap().to_string();
+    images.get(random_index).unwrap().to_string()
 }
 
 /// Builds the request url

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,11 @@
+// Common utilities shared across modules
+
+/// Expand a leading "~/" to the user's home directory. If expansion fails, returns the input.
+pub fn expand_tilde(path: &str) -> String {
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(rest).to_string_lossy().into_owned();
+        }
+    }
+    path.to_string()
+}


### PR DESCRIPTION
- Treat ~/… as home-expanded for is_local_path and file reads
- Persist wallpapers as PNG to avoid JPEG RGBA unsupported errors
- Keep clippy clean (remove needless returns, minor allows)